### PR TITLE
Fixing #volume being called in Vector instead of Dimension

### DIFF
--- a/lib/box_packer/box.rb
+++ b/lib/box_packer/box.rb
@@ -5,9 +5,14 @@ require_relative 'position'
 module BoxPacker
 	class Box
 		extend Forwardable
-		attr_initialize :dimensions, [:position]
+
 		def_delegators :dimensions, :volume, :each_rotation, :width, :height, :depth
 		attr_accessor :dimensions, :position
+
+		def initialize(dimensions, options={})
+			@dimensions = dimensions.is_a?(Dimensions) ? dimensions : Dimensions[*dimensions]
+			@position = options[:position]
+		end
 
 		def position
 			@position ||= Position[0, 0, 0]
@@ -22,7 +27,7 @@ module BoxPacker
 		end
 
 		def sub_boxes(item)	
-			sub_boxes = sub_boxes_args(item).select{ |(d, p)| d.volume > 0 }
+			sub_boxes = sub_boxes_args(item).select{ |(d, p)| Dimensions[*d].volume > 0 }
 			sub_boxes.map!{ |args| Box.new(*args) }
 			sub_boxes.sort_by!(&:volume).reverse!
 		end


### PR DESCRIPTION
This commit fixes an error occurring when trying to pack using weight. 5 specs that were failing are now passing. 
