### PR TITLE
Fix break_up_space to prevent overlaps and overhangs

### DIFF
--- a/box_packer.rb
+++ b/box_packer.rb
@@ -89,9 +89,9 @@ module BoxPacker
       [
         {
           dimensions: [
-            space[:dimensions][0],
+            space[:dimensions][0] - placement[:dimensions][0],
             space[:dimensions][1],
-            space[:dimensions][2] - placement[:dimensions][0]
+            space[:dimensions][2]
           ],
           position: [
             space[:position][0] + placement[:dimensions][0],
@@ -102,8 +102,8 @@ module BoxPacker
         {
           dimensions: [
             placement[:dimensions][0],
-            space[:dimensions][1],
-            space[:dimensions][2] - placement[:dimensions][1]
+            space[:dimensions][1] - placement[:dimensions][1],
+            placement[:dimensions][2]
           ],
           position: [
             space[:position][0],
@@ -114,7 +114,7 @@ module BoxPacker
         {
           dimensions: [
             placement[:dimensions][0],
-            placement[:dimensions][1],
+            space[:dimensions][1],
             space[:dimensions][2] - placement[:dimensions][2]
           ],
           position: [


### PR DESCRIPTION
Possible fix for Issue #9

NOTE: I added an additional change which prevents 'overhangs'. I'm not sure if this is desired behaviour for this library or not (it is for my application).